### PR TITLE
Change rule messages to be less prompting

### DIFF
--- a/src/rules/all.ts
+++ b/src/rules/all.ts
@@ -20,17 +20,17 @@ export default createEslintRule<Options, MessageIds>({
   meta: {
     type: "problem",
     docs: {
-      description: "force strict null checks",
+      description: "Enforce strict null checks",
       recommended: "warn",
     },
     schema: [],
     messages: {
       safeMemberAccess:
-        "Accessing member of nullable variable should be done using chain expression (?.)",
+          "Member is possibly nullish and should be checked. Consider accessing the member using the optional chaining operator (?.)",
       safeDeclaration:
-        "Assigning nullable value to non nullable variable (you may use ?? for default value)",
+          "A nullish value shouldn't be assigned to a non-nullish type.",
       safeFunctionArguments:
-        "Passing nullable argument to function that expects non nullable",
+          "Don't pass nullish arguments to a function that expects a non-nullish type.",
     },
   },
   defaultOptions: [],


### PR DESCRIPTION
I would like to suggest making the messages less prompting. For instance, there are situations where using the chain operator (?.) is not the right way of handling null values (i.e. because the function should be aborted by throwing an error).

Also, I would replace the term _nullable_ with _nullish_ as this is more accurate.