### PR TITLE
Resolve generic call expression type

### DIFF
--- a/src/rules/all.ts
+++ b/src/rules/all.ts
@@ -93,20 +93,16 @@ export default createEslintRule<Options, MessageIds>({
       },
       CallExpression(node) {
         const originalNode = parserServices.esTreeNodeToTSNodeMap.get(node);
-        const expressionType = getConstrainedTypeAtLocation(
-          checker,
-          originalNode.expression
-        );
-        const signatures = expressionType.getCallSignatures();
-        if (signatures.length !== 1) return;
+        const signature = checker.getResolvedSignature(originalNode);
+        if (!signature) return;
 
-        const paramsInSig = signatures[0].getParameters();
+        const paramsInSig = signature.getParameters();
 
         const nullableSig = paramsInSig.map((p) => {
           const declaration = p.declarations?.[0];
           if (!declaration) return false; // if cannot get declaration, assume it is not nullable
 
-          const paramType = getConstrainedTypeAtLocation(checker, declaration);
+          const paramType = checker.getTypeOfSymbolAtLocation(p, declaration);
           return isNullableType(paramType) || isTypeAnyType(paramType);
         });
 

--- a/src/utils/compare.ts
+++ b/src/utils/compare.ts
@@ -16,7 +16,7 @@ export function compareTypeObjects(
   left: Type,
   right: Type,
   checker: TypeChecker,
-  recursionStack?: any[] = []
+  recursionStack: any[] = []
 ) {
   if (recursionStack.includes(left)) {
     return true;

--- a/test/rules/all.test.ts
+++ b/test/rules/all.test.ts
@@ -61,6 +61,16 @@ const validStatements = [
   for (const key in t) {
   }
   `,
+  `
+  type Dispatch<A> = (value: A) => void;
+  type SetStateAction<S> = S | ((prevState: S) => S);
+  function useState<S>(): [S | undefined, Dispatch<SetStateAction<S | undefined>>] {
+    throw new Error();
+  }
+
+  const [st, setSt] = useState<number>();
+  setSt(undefined);
+  `,
 ];
 
 const invalidStatemetsMemberAccess = [

--- a/test/rules/all.test.ts
+++ b/test/rules/all.test.ts
@@ -11,7 +11,7 @@ const ruleTester: RuleTester = new RuleTester({
     tsconfigRootDir: root,
   },
 });
-const valid = [
+const validStatements = [
   `
   function foo() {
     const a = 1 as number | undefined;
@@ -128,6 +128,10 @@ const invalidFunctionArguments = [
   `,
 ];
 
+const valid = validStatements.map((st) => ({
+  code: st,
+}));
+
 const invalid = [
   ...invalidStatemetsMemberAccess.map((st) => ({
     code: st,
@@ -144,6 +148,6 @@ const invalid = [
 ];
 
 ruleTester.run(RULE_NAME, rule, {
-  valid: [],
+  valid,
   invalid,
 });


### PR DESCRIPTION
Issue #16
The problem is that we should resolve generic type of argument to have an availability to check it with `isNullableType`.

For the new valid test case:

Old behavior:
`undefined` is passing as a parameter of type `SetStateAction<S | undefined>` for which the `isNullableType` is `false`.

New behavior:
`undefined` is passing as a parameter of type `number | undefined | (((prevState: number | undefined) => number | undefined))` for which the `isNullableType` is `true`.