### PR TITLE
Fix unknown not recognized as nullable

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,5 @@ module.exports = {
       isolatedModules: true,
     },
   },
+  transformIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/dist/"],
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-strict-null-checks",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Eslint plugin that aims to reproduce strictNullCheck from tsconfig for easier migration",
   "main": "dist/index.js",
   "scripts": {

--- a/src/rules/all.ts
+++ b/src/rules/all.ts
@@ -26,11 +26,11 @@ export default createEslintRule<Options, MessageIds>({
     schema: [],
     messages: {
       safeMemberAccess:
-          "Member is possibly nullish and should be checked. Consider accessing the member using the optional chaining operator (?.)",
+        "Member is possibly nullish and should be checked. Consider accessing the member using the optional chaining operator (?.)",
       safeDeclaration:
-          "A nullish value shouldn't be assigned to a non-nullish type.",
+        "A nullish value shouldn't be assigned to a non-nullish type.",
       safeFunctionArguments:
-          "Don't pass nullish arguments to a function that expects a non-nullish type.",
+        "Don't pass nullish arguments to a function that expects a non-nullish type.",
     },
   },
   defaultOptions: [],
@@ -75,7 +75,7 @@ export default createEslintRule<Options, MessageIds>({
         // if variable is initialized by null (unless it is nullable or any)
         if (
           isNullableType(initType) &&
-          !(isNullableType(idType) || isTypeAnyType(idType))
+          !isNullableType(idType, { isReceiver: true })
         ) {
           return context.report({
             messageId: "safeDeclaration",
@@ -103,7 +103,7 @@ export default createEslintRule<Options, MessageIds>({
           if (!declaration) return false; // if cannot get declaration, assume it is not nullable
 
           const paramType = checker.getTypeOfSymbolAtLocation(p, declaration);
-          return isNullableType(paramType) || isTypeAnyType(paramType);
+          return isNullableType(paramType, { isReceiver: true });
         });
 
         const argTypes = originalNode.arguments.map((arg) =>

--- a/test/rules/all.test.ts
+++ b/test/rules/all.test.ts
@@ -11,7 +11,7 @@ const ruleTester: RuleTester = new RuleTester({
     tsconfigRootDir: root,
   },
 });
-const validStatements = [
+const generalValidStatements = [
   `
   function foo() {
     const a = 1 as number | undefined;
@@ -83,7 +83,7 @@ const validStatements = [
   const [st, setSt] = useState<number>();
   setSt(undefined);
   `,
-];
+].map((st) => ({ name: "general valid", code: st }));
 
 const invalidStatemetsMemberAccess = [
   `
@@ -167,9 +167,24 @@ const invalidFunctionArguments = [
   `,
 ];
 
-const valid = validStatements.map((st) => ({
-  code: st,
-}));
+/**
+ * Passing nullable to a function accepting those should not give a warning.
+ * issue @link https://github.com/JaroslawPokropinski/eslint-plugin-strict-null-checks/issues/19
+ */
+const validCallNullableArg = [
+  {
+    name: "valid call with undefined",
+    code: `
+    // test for issue 19
+    function foo(v: unknown): unknown {
+      return v;
+    }
+    foo(undefined);
+    `,
+  },
+];
+
+const valid = [...generalValidStatements, ...validCallNullableArg];
 
 const invalid = [
   ...invalidStatemetsMemberAccess.map((st) => ({


### PR DESCRIPTION
This PR switches to ` isNullableType(paramType, { isReceiver: true })` instead of explicitly checking for any to handle more possibilities such as unknown.

Fixes #19