### PR TITLE
Fix message parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-strict-null-checks",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Eslint plugin that aims to reproduce strictNullCheck from tsconfig for easier migration",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-strict-null-checks",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Eslint plugin that aims to reproduce strictNullCheck from tsconfig for easier migration",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "ts-jest": "^27.0.7",
     "typescript": "4.5.5"
   },
+  "peerDependencies": {
+    "typescript": ">=3.9.4"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/JaroslawPokropinski/eslint-plugin-strict-null-check.git"

--- a/src/rules/all.ts
+++ b/src/rules/all.ts
@@ -27,9 +27,14 @@ export default createEslintRule<Options, MessageIds>({
     return {
       Program(astNode) {
         const semErrors = parserServices.program.getSemanticDiagnostics();
-        const code = parserServices.esTreeNodeToTSNodeMap.get(astNode).text;
+        const tsNode = parserServices.esTreeNodeToTSNodeMap.get(astNode);
+        const code = tsNode.text;
 
         semErrors.forEach((error) => {
+          // Only report errors in the current file.
+          if (!error.file || error.file.fileName !== tsNode.fileName) {
+            return;
+          }
           if (error.reportsUnnecessary) return;
           if (error.category !== DiagnosticCategory.Error) return;
 

--- a/src/rules/all.ts
+++ b/src/rules/all.ts
@@ -38,9 +38,14 @@ export default createEslintRule<Options, MessageIds>({
           if (error.reportsUnnecessary) return;
           if (error.category !== DiagnosticCategory.Error) return;
 
+          const firstMessageInChain =
+            typeof error.messageText === "string"
+              ? error.messageText
+              : error.messageText.messageText;
+
           context.report({
             messageId: "typescriptError",
-            data: { errorMessage: error.messageText },
+            data: { errorMessage: firstMessageInChain },
             loc: posToLoc(code, error.start!, error.start! + error.length!),
           });
         });


### PR DESCRIPTION
I added a check making sure that error message is a string. Otherwise it is a chain of errors so I'll display only the first one.
Fixes #24, #27.
